### PR TITLE
Fix Lighthouse accessibility violations for slide ARIA attributes and hidden tabbable descendants

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ This plugin implements the following accessibility features:
 - Adds `aria-roledescription="carousel"` to identify it as a carousel
 - Adds proper `aria-label` (or respects existing labels)
 - Adds `role="group"` and `aria-roledescription="slide"` to slides
-- Applies `aria-hidden="true"` to non-visible slides
-- Sets `aria-setsize` and `aria-posinset` for proper slide position information
+- Applies `aria-hidden="true"` only to slides outside the current viewport
+- Sets hidden slide descendants to `tabindex="-1"` and restores prior tabindex values when slides re-enter view
 
 ### Live Region for Announcements
 

--- a/src/__tests__/a11y.test.ts
+++ b/src/__tests__/a11y.test.ts
@@ -59,6 +59,10 @@ describe("A11y Plugin", () => {
 
   it("should apply correct ARIA attributes to carousel elements", () => {
     embla = EmblaCarousel(container, {}, [A11y()]);
+    const a11yPlugin = embla.plugins().a11y;
+
+    vi.spyOn(embla, "slidesInView").mockReturnValue([0]);
+    a11yPlugin.update();
 
     // Check root element
     expect(container.getAttribute("role")).toBe("region");
@@ -72,12 +76,12 @@ describe("A11y Plugin", () => {
       expect(slide.getAttribute("aria-label")).toBe(
         `Slide ${index + 1} of ${slides.length}`,
       );
-      expect(slide.getAttribute("aria-setsize")).toBe(`${slides.length}`);
-      expect(slide.getAttribute("aria-posinset")).toBe(`${index + 1}`);
+      expect(slide.hasAttribute("aria-setsize")).toBe(false);
+      expect(slide.hasAttribute("aria-posinset")).toBe(false);
     });
 
     // First slide should be visible, others hidden
-    expect(slides[0].getAttribute("aria-hidden")).toBe("false");
+    expect(slides[0].hasAttribute("aria-hidden")).toBe(false);
     expect(slides[1].getAttribute("aria-hidden")).toBe("true");
     expect(slides[2].getAttribute("aria-hidden")).toBe("true");
   });
@@ -109,19 +113,98 @@ describe("A11y Plugin", () => {
   it("should update aria-hidden when slide changes", () => {
     embla = EmblaCarousel(container, {}, [A11y()]);
     const a11yPlugin = embla.plugins().a11y;
+    const slidesInView = vi.spyOn(embla, "slidesInView");
 
     // Initially first slide is visible
-    expect(slides[0].getAttribute("aria-hidden")).toBe("false");
+    slidesInView.mockReturnValue([0]);
+    a11yPlugin.update();
+    expect(slides[0].hasAttribute("aria-hidden")).toBe(false);
     expect(slides[1].getAttribute("aria-hidden")).toBe("true");
 
-    // Manually simulate changing to the second slide
-    // We need to mock this because scrollNext() doesn't work in jsdom/happy-dom
-    vi.spyOn(embla, "selectedScrollSnap").mockReturnValue(1);
+    // Manually simulate changing the visible slide
+    slidesInView.mockReturnValue([1]);
     a11yPlugin.update();
 
     // Now second slide should be visible
     expect(slides[0].getAttribute("aria-hidden")).toBe("true");
-    expect(slides[1].getAttribute("aria-hidden")).toBe("false");
+    expect(slides[1].hasAttribute("aria-hidden")).toBe(false);
+  });
+
+  it("should keep all slides in view exposed to assistive technology", () => {
+    embla = EmblaCarousel(container, {}, [A11y()]);
+    const a11yPlugin = embla.plugins().a11y;
+
+    vi.spyOn(embla, "slidesInView").mockReturnValue([0, 1]);
+    a11yPlugin.update();
+
+    expect(slides[0].hasAttribute("aria-hidden")).toBe(false);
+    expect(slides[1].hasAttribute("aria-hidden")).toBe(false);
+    expect(slides[2].getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("should remove hidden slide descendants from the tab order", () => {
+    slides[1].innerHTML = `
+      <a href="#hidden-link">Hidden Link</a>
+      <button type="button" tabindex="2">Hidden Button</button>
+    `;
+
+    embla = EmblaCarousel(container, {}, [A11y()]);
+    const a11yPlugin = embla.plugins().a11y;
+
+    vi.spyOn(embla, "slidesInView").mockReturnValue([0]);
+    a11yPlugin.update();
+
+    const hiddenLink = slides[1].querySelector("a")!;
+    const hiddenButton = slides[1].querySelector("button")!;
+
+    expect(slides[1].getAttribute("aria-hidden")).toBe("true");
+    expect(hiddenLink.getAttribute("tabindex")).toBe("-1");
+    expect(hiddenLink.getAttribute("data-embla-tabindex")).toBe("");
+    expect(hiddenButton.getAttribute("tabindex")).toBe("-1");
+    expect(hiddenButton.getAttribute("data-embla-tabindex")).toBe("2");
+  });
+
+  it("should restore descendant tabindex values when a slide becomes visible again", () => {
+    slides[1].innerHTML = `
+      <a href="#visible-link">Visible Link</a>
+      <button type="button" tabindex="2">Visible Button</button>
+    `;
+
+    embla = EmblaCarousel(container, {}, [A11y()]);
+    const a11yPlugin = embla.plugins().a11y;
+    const slidesInView = vi.spyOn(embla, "slidesInView");
+    const visibleLink = slides[1].querySelector("a")!;
+    const visibleButton = slides[1].querySelector("button")!;
+
+    slidesInView.mockReturnValue([0]);
+    a11yPlugin.update();
+
+    slidesInView.mockReturnValue([1]);
+    a11yPlugin.update();
+
+    expect(slides[1].hasAttribute("aria-hidden")).toBe(false);
+    expect(visibleLink.hasAttribute("tabindex")).toBe(false);
+    expect(visibleLink.hasAttribute("data-embla-tabindex")).toBe(false);
+    expect(visibleButton.getAttribute("tabindex")).toBe("2");
+    expect(visibleButton.hasAttribute("data-embla-tabindex")).toBe(false);
+  });
+
+  it("should not mutate descendants that are already out of the tab order", () => {
+    slides[1].innerHTML = `
+      <button type="button" tabindex="-1">Already Untabbable</button>
+    `;
+
+    embla = EmblaCarousel(container, {}, [A11y()]);
+    const a11yPlugin = embla.plugins().a11y;
+
+    vi.spyOn(embla, "slidesInView").mockReturnValue([0]);
+    a11yPlugin.update();
+
+    const button = slides[1].querySelector("button")!;
+
+    expect(slides[1].getAttribute("aria-hidden")).toBe("true");
+    expect(button.getAttribute("tabindex")).toBe("-1");
+    expect(button.hasAttribute("data-embla-tabindex")).toBe(false);
   });
 
   it("should announce slide changes", () => {
@@ -175,16 +258,26 @@ describe("A11y Plugin", () => {
   });
 
   it("should remove all ARIA attributes and live region on destroy", () => {
+    slides[1].innerHTML = `<button type="button" tabindex="3">Hidden Button</button>`;
     embla = EmblaCarousel(container, {}, [A11y()]);
+    const a11yPlugin = embla.plugins().a11y;
+
+    vi.spyOn(embla, "slidesInView").mockReturnValue([0]);
+    a11yPlugin.update();
 
     // Verify live region exists
     expect(container.querySelector(".embla__live-region")).not.toBeNull();
+    expect(slides[1].querySelector("button")?.getAttribute("tabindex")).toBe("-1");
 
     // Destroy carousel
     embla.destroy();
 
     // Live region should be removed
     expect(container.querySelector(".embla__live-region")).toBeNull();
+    expect(slides[1].querySelector("button")?.getAttribute("tabindex")).toBe("3");
+    expect(
+      slides[1].querySelector("button")?.hasAttribute("data-embla-tabindex"),
+    ).toBe(false);
   });
 
   // New tests for respecting user-provided attributes
@@ -217,10 +310,36 @@ describe("A11y Plugin", () => {
     slides[1].setAttribute("aria-hidden", "false"); // This should be changed
 
     embla = EmblaCarousel(container, {}, [A11y()]);
+    const a11yPlugin = embla.plugins().a11y;
+
+    vi.spyOn(embla, "slidesInView").mockReturnValue([0]);
+    a11yPlugin.update();
 
     // aria-hidden should be set based on the carousel state, regardless of initial values
-    expect(slides[0].getAttribute("aria-hidden")).toBe("false");
+    expect(slides[0].hasAttribute("aria-hidden")).toBe(false);
     expect(slides[1].getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("should remove invalid slide set position attributes", () => {
+    slides[0].setAttribute("aria-setsize", "3");
+    slides[0].setAttribute("aria-posinset", "1");
+
+    embla = EmblaCarousel(container, {}, [A11y()]);
+
+    expect(slides[0].hasAttribute("aria-setsize")).toBe(false);
+    expect(slides[0].hasAttribute("aria-posinset")).toBe(false);
+  });
+
+  it("should preserve user-provided set position attributes for non-group roles", () => {
+    slides[0].setAttribute("role", "listitem");
+    slides[0].setAttribute("aria-setsize", "3");
+    slides[0].setAttribute("aria-posinset", "1");
+
+    embla = EmblaCarousel(container, {}, [A11y()]);
+
+    expect(slides[0].getAttribute("role")).toBe("listitem");
+    expect(slides[0].getAttribute("aria-setsize")).toBe("3");
+    expect(slides[0].getAttribute("aria-posinset")).toBe("1");
   });
 
   // Tests for developer warnings

--- a/src/a11y.ts
+++ b/src/a11y.ts
@@ -21,6 +21,19 @@ export type A11yPluginType = CreatePluginType<
 
 export type A11yPluginOptionsType = A11yPluginType["options"];
 
+const TABBABLE_DESCENDANT_SELECTOR = [
+  "a[href]",
+  "area[href]",
+  'input:not([disabled]):not([type="hidden"])',
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "button:not([disabled])",
+  "summary",
+  "[tabindex]",
+].join(", ");
+
+const PREVIOUS_TABINDEX_ATTRIBUTE = "data-embla-tabindex";
+
 class A11yPlugin implements A11yPluginType {
   readonly name = "a11y";
   readonly options: A11yPluginOptionsType;
@@ -61,30 +74,7 @@ class A11yPlugin implements A11yPluginType {
   update(): void {
     if (!this.embla) return;
 
-    const selectedIndex = this.embla.selectedScrollSnap();
-
-    // Update slide attributes
-    this.slideElements.forEach((slide, index) => {
-      // Set aria-hidden on non-visible slides
-      this.safeSetAttribute(
-        slide,
-        "aria-hidden",
-        index === selectedIndex ? "false" : "true",
-      );
-
-      // Update position in set if user hasn't set these
-      if (!this.userHasAttribute(slide, "aria-setsize")) {
-        this.safeSetAttribute(
-          slide,
-          "aria-setsize",
-          `${this.slideElements.length}`,
-        );
-      }
-
-      if (!this.userHasAttribute(slide, "aria-posinset")) {
-        this.safeSetAttribute(slide, "aria-posinset", `${index + 1}`);
-      }
-    });
+    this.updateSlideVisibility();
 
     // Announce current slide if enabled
     if (this.options.announceSlideChanges) {
@@ -113,6 +103,9 @@ class A11yPlugin implements A11yPluginType {
 
     // Remove live region
     this.liveRegion?.parentElement?.removeChild(this.liveRegion);
+    this.slideElements.forEach((slide) => {
+      this.updateSlideHiddenState(slide, false);
+    });
 
     this.embla = null;
     this.rootElement = null;
@@ -141,8 +134,6 @@ class A11yPlugin implements A11yPluginType {
         "aria-describedby",
         "aria-roledescription",
         "role",
-        "aria-setsize",
-        "aria-posinset",
       ].forEach((attr) => {
         if (element.hasAttribute(attr)) {
           attributes.add(attr);
@@ -235,6 +226,11 @@ class A11yPlugin implements A11yPluginType {
       this.safeSetAttribute(slide, "role", "group");
       this.safeSetAttribute(slide, "aria-roledescription", "slide");
 
+      if (slide.getAttribute("role") === "group") {
+        slide.removeAttribute("aria-setsize");
+        slide.removeAttribute("aria-posinset");
+      }
+
       // If slides don't have accessible names, set default
       if (!hasSlideLabel) {
         const defaultLabel = `Slide ${index + 1} of ${this.slideElements.length}`;
@@ -287,15 +283,97 @@ class A11yPlugin implements A11yPluginType {
     const handleSelect = (): void => {
       this.#onSlideChange();
     };
+    const handleSlidesInView = (): void => {
+      this.updateSlideVisibility();
+    };
 
     // Listen for slide changes
     this.embla.on("select", handleSelect);
+    this.embla.on("slidesInView", handleSlidesInView);
 
     // Add cleanup function
     this.cleanupFunctions.push(() => {
       if (this.embla) {
         this.embla.off("select", handleSelect);
+        this.embla.off("slidesInView", handleSlidesInView);
       }
+    });
+  }
+
+  /**
+   * Keep slide visibility aligned with Embla's in-view calculation
+   */
+  private updateSlideVisibility(): void {
+    if (!this.embla) return;
+
+    const visibleIndexes = new Set(this.embla.slidesInView());
+
+    this.slideElements.forEach((slide, index) => {
+      this.updateSlideHiddenState(slide, !visibleIndexes.has(index));
+    });
+  }
+
+  /**
+   * Update a slide's hidden state and tab order
+   */
+  private updateSlideHiddenState(slide: HTMLElement, isHidden: boolean): void {
+    const tabbableDescendants = this.getTabbableDescendants(slide);
+
+    if (isHidden) {
+      this.safeSetAttribute(slide, "aria-hidden", "true");
+      this.disableTabbableDescendants(tabbableDescendants);
+
+      return;
+    }
+
+    slide.removeAttribute("aria-hidden");
+    this.restoreTabbableDescendants(tabbableDescendants);
+  }
+
+  /**
+   * Find descendants that should be removed from or restored to the tab order
+   */
+  private getTabbableDescendants(slide: HTMLElement): HTMLElement[] {
+    return Array.from(
+      slide.querySelectorAll<HTMLElement>(TABBABLE_DESCENDANT_SELECTOR),
+    ).filter((element) => {
+      return (
+        element.tabIndex >= 0 ||
+        element.hasAttribute(PREVIOUS_TABINDEX_ATTRIBUTE)
+      );
+    });
+  }
+
+  /**
+   * Remove descendants from the tab order and remember their prior tabindex
+   */
+  private disableTabbableDescendants(descendants: HTMLElement[]): void {
+    descendants.forEach((element) => {
+      if (!element.hasAttribute(PREVIOUS_TABINDEX_ATTRIBUTE)) {
+        element.setAttribute(
+          PREVIOUS_TABINDEX_ATTRIBUTE,
+          element.getAttribute("tabindex") ?? "",
+        );
+      }
+
+      element.setAttribute("tabindex", "-1");
+    });
+  }
+
+  /**
+   * Restore tabindex values saved while the slide was hidden
+   */
+  private restoreTabbableDescendants(descendants: HTMLElement[]): void {
+    descendants.forEach((element) => {
+      const previousTabIndex = element.getAttribute(PREVIOUS_TABINDEX_ATTRIBUTE);
+
+      if (previousTabIndex === "") {
+        element.removeAttribute("tabindex");
+      } else if (previousTabIndex !== null) {
+        element.setAttribute("tabindex", previousTabIndex);
+      }
+
+      element.removeAttribute(PREVIOUS_TABINDEX_ATTRIBUTE);
     });
   }
 


### PR DESCRIPTION
## Summary

This PR fixes two accessibility issues reported by Lighthouse:

- `[aria-*] attributes do not match their roles`
- `[aria-hidden="true"] elements contain focusable descendants`

These issues occur when slides are assigned `role="group"` while still having
`aria-setsize` and `aria-posinset`, and when hidden slides still expose
tabbable descendants.

## Changes

### 1. Remove invalid ARIA attributes from slides

Slides use:
- `role="group"`
- `aria-roledescription="slide"`

However `aria-setsize` and `aria-posinset` are not valid for elements with
`role="group"` and trigger Lighthouse accessibility warnings.

This PR removes those attributes when the slide role is `group`.

### 2. Prevent hidden slides from exposing tabbable descendants

When a slide is hidden with `aria-hidden="true"` interactive descendants such as links or buttons may still remain in the tab
order, causing accessibility violations.

This PR ensures that:

- hidden slides receive `aria-hidden="true"`
- tabbable descendants temporarily receive `tabindex="-1"`
- previous `tabindex` values are stored using a data attribute
- original values are restored when the slide becomes visible again

This prevents keyboard navigation from reaching hidden slide content while
preserving existing element behavior.

## Behavior

Visible slides:

- `aria-hidden` removed
- tabbable descendants restored to their previous `tabindex`

Hidden slides:

- `aria-hidden="true"`
- tabbable descendants removed from tab order

Visibility is determined using Embla's `slidesInView()` API.

## Before

Lighthouse reports:

- `[aria-*] attributes do not match their roles`
- `[aria-hidden="true"] elements contain focusable descendants`

<img width="606" height="396" alt="Screenshot 2026-03-11 at 00 06 35" src="https://github.com/user-attachments/assets/853b4550-1c6b-414a-a7cd-740a41bfcfd0" />

## After

<img width="616" height="370" alt="Screenshot 2026-03-11 at 00 06 46" src="https://github.com/user-attachments/assets/73fc4eee-17c8-4a66-828d-c66587af80f9" />

Closes https://github.com/bluecadet/embla-carousel-a11y/issues/1
